### PR TITLE
correct CMakeLists. octomap_INCLUDE_DIRS(or LIB..) to OCTOMAP_INCLUDE_DI...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,11 @@ catkin_package(
 include_directories(include 
                     ${catkin_INCLUDE_DIRS} 
                     ${Boost_INCLUDE_DIRS} 
-                    ${octomap_INCLUDE_DIRS})
+                    ${OCTOMAP_INCLUDE_DIRS})
 
 link_directories(${catkin_LIBRARY_DIRS}
                  ${Boost_LIBRARY_DIRS}
-                 ${octomap_LIBRARY_DIRS}) 
+                 ${OCTOMAP_LIBRARY_DIRS}) 
 
 
 qt4_wrap_cpp(MOC_FILES
@@ -47,7 +47,7 @@ set(SOURCE_FILES
 )
 
 add_library(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${Boost_LIBRARIES} ${octomap_LIBRARIES} ${catkin_LIBRARIES} -ldefault_plugin)
+target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${catkin_LIBRARIES} -ldefault_plugin)
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}


### PR DESCRIPTION
...RS

Same reason as pull-quest to groovy-devel.

To patch the issue https://github.com/OctoMap/octomap_rviz_plugins/issues/2
