### PR TITLE
octomap rviz plugin crashes with new rviz feature

### DIFF
--- a/src/occupancy_grid_display.cpp
+++ b/src/occupancy_grid_display.cpp
@@ -146,10 +146,12 @@ OccupancyGridDisplay::~OccupancyGridDisplay()
 
   unsubscribe();
 
-  for (i = 0; i < max_octree_depth_; ++i)
-    delete cloud_[i];
+  for (std::vector<rviz::PointCloud*>::iterator it = cloud_.begin(); it != cloud_.end(); ++it) {
+    delete *(it);
+  }
 
-  scene_node_->detachAllObjects();
+  if (scene_node_)
+    scene_node_->detachAllObjects();
 }
 
 void OccupancyGridDisplay::updateQueueSize()


### PR DESCRIPTION
See ros-visualization/rviz#680

When clicking 'Add Display' I get:

```
Program received signal SIGSEGV, Segmentation fault.
0x00007fff810d71d7 in octomap_rviz_plugin::OccupancyGridDisplay::~OccupancyGridDisplay() ()
   from /opt/ros/hydro/lib//liboctomap_rviz_plugins.so
(gdb) bt
#0  0x00007fff810d71d7 in octomap_rviz_plugin::OccupancyGridDisplay::~OccupancyGridDisplay() ()
   from /opt/ros/hydro/lib//liboctomap_rviz_plugins.so
#1  0x00007fff810d7349 in octomap_rviz_plugin::OccupancyGridDisplay::~OccupancyGridDisplay() ()
   from /opt/ros/hydro/lib//liboctomap_rviz_plugins.so
#2  0x00007ffff7a4a16e in boost::checked_delete<rviz::Display> (x=0x160d780) at /usr/include/boost/checked_delete.hpp:34
#3  0x00007ffff7a4b304 in boost::detail::sp_counted_impl_p<rviz::Display>::dispose (this=0x160dd20)
    at /usr/include/boost/smart_ptr/detail/sp_counted_impl.hpp:78
#4  0x00007ffff79deab4 in boost::detail::sp_counted_base::release (this=0x160dd20)
    at /usr/include/boost/smart_ptr/detail/sp_counted_base_gcc_x86.hpp:145
#5  0x00007ffff79deb43 in boost::detail::shared_count::~shared_count (this=0x7fffffffc4f8, __in_chrg=<optimized out>)
    at /usr/include/boost/smart_ptr/detail/shared_count.hpp:217
#6  0x00007ffff7a4735a in boost::shared_ptr<rviz::Display>::~shared_ptr (this=0x7fffffffc4f0, __in_chrg=<optimized out>)
    at /usr/include/boost/smart_ptr/shared_ptr.hpp:168
#7  0x00007ffff7a467df in rviz::TopicDisplayWidget::findPlugins (this=0x15d8a80, factory=0x9346b0)
    at /home/william/moveit_plugin_ws/src/rviz/src/rviz/add_display_dialog.cpp:592
#8  0x00007ffff7a45ceb in rviz::TopicDisplayWidget::fill (this=0x15d8a80, factory=0x9346b0)
    at /home/william/moveit_plugin_ws/src/rviz/src/rviz/add_display_dialog.cpp:515
#9  0x00007ffff7a43d17 in rviz::AddDisplayDialog::AddDisplayDialog (this=0x131ca90, factory=0x9346b0, object_type=..., 
    disallowed_display_names=..., disallowed_class_lookup_names=..., lookup_name_output=0x7fffffffc900, 
    display_name_output=0x7fffffffc910, topic_output=0x7fffffffc920, datatype_output=0x7fffffffc930, parent=0x0)
    at /home/william/moveit_plugin_ws/src/rviz/src/rviz/add_display_dialog.cpp:203
#10 0x00007ffff79fc048 in rviz::DisplaysPanel::onNewDisplay (this=0xdd0cf0)
    at /home/william/moveit_plugin_ws/src/rviz/src/rviz/displays_panel.cpp:114
#11 0x00007ffff7afdad5 in rviz::DisplaysPanel::qt_static_metacall (_o=0xdd0cf0, _c=QMetaObject::InvokeMetaMethod, _id=0, _a=0x7fffffffcb20)
    at /home/william/moveit_plugin_ws/build/rviz/src/rviz/moc_displays_panel.cxx:54
#12 0x00007ffff2989281 in QMetaObject::activate(QObject*, QMetaObject const*, int, void**) () from /usr/lib/x86_64-linux-gnu/libQtCore.so.4
#13 0x00007ffff738ac72 in QAbstractButton::clicked(bool) () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
#14 0x00007ffff70c8a4e in ?? () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
#15 0x00007ffff70c9d8b in ?? () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
#16 0x00007ffff70c9ffc in QAbstractButton::mouseReleaseEvent(QMouseEvent*) () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
#17 0x00007ffff6d4b144 in QWidget::event(QEvent*) () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
#18 0x00007ffff6cfa894 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
#19 0x00007ffff6d000bf in QApplication::notify(QObject*, QEvent*) () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
#20 0x00007ffff2974e9c in QCoreApplication::notifyInternal(QObject*, QEvent*) () from /usr/lib/x86_64-linux-gnu/libQtCore.so.4
#21 0x00007ffff6cfb862 in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool) () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
#22 0x00007ffff6d7abf5 in ?? () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
#23 0x00007ffff6d79bae in QApplication::x11ProcessEvent(_XEvent*) () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
#24 0x00007ffff6da30d2 in ?? () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
#25 0x00007ffff16f9d53 in g_main_context_dispatch () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#26 0x00007ffff16fa0a0 in ?? () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#27 0x00007ffff16fa164 in g_main_context_iteration () from /lib/x86_64-linux-gnu/libglib-2.0.so.0
#28 0x00007ffff29a43bf in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) ()
   from /usr/lib/x86_64-linux-gnu/libQtCore.so.4
#29 0x00007ffff6da2d5e in ?? () from /usr/lib/x86_64-linux-gnu/libQtGui.so.4
#30 0x00007ffff2973c82 in QEventLoop::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /usr/lib/x86_64-linux-gnu/libQtCore.so.4
#31 0x00007ffff2973ed7 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () from /usr/lib/x86_64-linux-gnu/libQtCore.so.4
#32 0x00007ffff2978f67 in QCoreApplication::exec() () from /usr/lib/x86_64-linux-gnu/libQtCore.so.4
#33 0x0000000000400fd7 in main (argc=1, argv=0x7fffffffe1a8) at /home/william/moveit_plugin_ws/src/rviz/src/rviz/main.cpp:41
```

I am working on a pull request to solve this.
