### PR TITLE
add fix for qt moc BOOST_JOIN problem for osx yosemite build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,10 @@ link_directories(${catkin_LIBRARY_DIRS}
                  ${OCTOMAP_LIBRARY_DIRS}) 
 
 
-qt4_wrap_cpp(MOC_FILES
+QT4_WRAP_CPP(MOC_FILES
   include/octomap_rviz_plugins/occupancy_grid_display.h
   include/octomap_rviz_plugins/occupancy_map_display.h
-  OPTIONS -DBOOST_TT_HAS_OPERATOR_HPP_INCLUDED
+  OPTIONS -DBOOST_TT_HAS_OPERATOR_HPP_INCLUDED -DBOOST_LEXICAL_CAST_INCLUDED 
 )
 
 set(SOURCE_FILES

--- a/include/octomap_rviz_plugins/occupancy_grid_display.h
+++ b/include/octomap_rviz_plugins/occupancy_grid_display.h
@@ -33,6 +33,7 @@
 #ifndef RVIZ_OCCUPANCY_GRID_DISPLAY_H
 #define RVIZ_OCCUPANCY_GRID_DISPLAY_H
 
+#ifndef Q_MOC_RUN 
 #include <ros/ros.h>
 
 #include <boost/shared_ptr.hpp>
@@ -44,6 +45,8 @@
 
 #include <rviz/display.h>
 #include "rviz/ogre_helpers/point_cloud.h"
+
+#endif
 
 namespace rviz {
 class RosTopicProperty;

--- a/include/octomap_rviz_plugins/occupancy_map_display.h
+++ b/include/octomap_rviz_plugins/occupancy_map_display.h
@@ -33,6 +33,8 @@
 #ifndef RVIZ_OCCUPANCY_MAP_DISPLAY_H
 #define RVIZ_OCCUPANCY_MAP_DISPLAY_H
 
+#ifndef Q_MOC_RUN 
+
 #include <qobject.h>
 
 #include <ros/ros.h>
@@ -43,6 +45,7 @@
 
 #include <message_filters/subscriber.h>
 
+#endif
 
 namespace octomap_rviz_plugin
 {


### PR DESCRIPTION
Solution for problem with Qt moc generator and BOOST_JOIN:

```
Generating include/octomap_rviz_plugins/moc_occupancy_grid_display.cxx
usr/local/Cellar/boost/1.56.0/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
make[3]: *** [extern/octomap_rviz_plugins/include/octomap_rviz_plugins/moc_occupancy_map_display.cxx] Error 1
```

I faced with this problem during build on `ros/indigo`+`rviz/hydro`+`osx/yosemite`+`homebrew/boost`:

```
$ brew info boost
boost: stable 1.56.0 (bottled), HEAD
http://www.boost.org
/usr/local/Cellar/boost/1.56.0 (10471 files, 438M) *
Poured from bottle
From: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/boost.rb

$ brew config
HOMEBREW_VERSION: 0.9.5
ORIGIN: https://github.com/Homebrew/homebrew
HEAD: 32923f435c7cf93820f434d6bdacf3bfdc3695eb
Last commit: 2 months ago
HOMEBREW_PREFIX: /usr/local
HOMEBREW_CELLAR: /usr/local/Cellar
CPU: quad-core 64-bit ivybridge
OS X: 10.10.2-x86_64
CLT: 6.1.1.0.1.1416017670
Clang: 6.0 build 600
X11: 2.7.7 => /opt/X11
System Ruby: 2.0.0-481
Perl: /usr/bin/perl
Python: /usr/local/bin/python => /usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/bin/python2.7
Ruby: /usr/bin/ruby
```

`-DBOOST_LEXICAL_CAST_INCLUDED` option for `QT4_WRAP_CPP` seems to be needed too for successful build.
By analogy with this commit https://github.com/ros-visualization/rviz/pull/589
