### PR TITLE
Trim Z values in the octomap visualization

### DIFF
--- a/include/octomap_rviz_plugins/occupancy_grid_display.h
+++ b/include/octomap_rviz_plugins/occupancy_grid_display.h
@@ -77,6 +77,8 @@ private Q_SLOTS:
   void updateOctreeRenderMode();
   void updateOctreeColorMode();
   void updateAlpha();
+  void updateMaxHeight();
+  void updateMinHeight();
 
 protected:
   // overrides from Display
@@ -115,12 +117,12 @@ protected:
   rviz::EnumProperty* octree_coloring_property_;
   rviz::IntProperty* tree_depth_property_;
   rviz::FloatProperty* alpha_property_;
+  rviz::FloatProperty* max_height_property_;
+  rviz::FloatProperty* min_height_property_;
 
   u_int32_t queue_size_;
-  std::size_t octree_depth_;
   uint32_t messages_received_;
   double color_factor_;
-  double alpha_;
 };
 
 } // namespace octomap_rviz_plugin

--- a/include/octomap_rviz_plugins/occupancy_map_display.h
+++ b/include/octomap_rviz_plugins/occupancy_map_display.h
@@ -72,7 +72,6 @@ protected:
 
   unsigned int octree_depth_;
   rviz::IntProperty* tree_depth_property_;
-
 };
 
 } // namespace rviz

--- a/src/occupancy_map_display.cpp
+++ b/src/occupancy_map_display.cpp
@@ -172,7 +172,7 @@ void OccupancyMapDisplay::handleOctomapBinaryMessage(const octomap_msgs::Octomap
   occupancy_map->info.width = width = (maxX-minX) / res + 1;
   occupancy_map->info.height = height = (maxY-minY) / res + 1;
   occupancy_map->info.origin.position.x = minX  - (res / (float)(1<<ds_shift) ) + res;
-  occupancy_map->info.origin.position.y = minY  - (res / (float)(1<<ds_shift) );;
+  occupancy_map->info.origin.position.y = minY  - (res / (float)(1<<ds_shift) );
 
   occupancy_map->data.clear();
   occupancy_map->data.resize(width*height, -1);


### PR DESCRIPTION
If we use an indoor octomap, this will include the ceiling and thus the visualization gets complicated, and the alpha value is not enough most of the times.

This PR add RViz parameters for online clipping of Z visualization. There are no check that ensure that `max>min`, but testing this I say it is no inconvenient (it just does not draw new octomaps).
