### PR TITLE
Update node frame from TF on every update.

### DIFF
--- a/include/octomap_rviz_plugins/occupancy_grid_display.h
+++ b/include/octomap_rviz_plugins/occupancy_grid_display.h
@@ -98,6 +98,8 @@ protected:
 
   void clear();
 
+  virtual bool updateFromTF();
+
   typedef std::vector<rviz::PointCloud::Point> VPoint;
   typedef std::vector<VPoint> VVPoint;
 
@@ -113,6 +115,7 @@ protected:
   // Ogre-rviz point clouds
   std::vector<rviz::PointCloud*> cloud_;
   std::vector<double> box_size_;
+  std_msgs::Header header_;
 
   // Plugin properties
   rviz::IntProperty* queue_size_property_;

--- a/src/occupancy_grid_display.cpp
+++ b/src/occupancy_grid_display.cpp
@@ -356,6 +356,7 @@ void OccupancyGridDisplay::update(float wall_dt, float ros_dt)
     }
     new_points_received_ = false;
   }
+  updateFromTF();
 }
 
 void OccupancyGridDisplay::reset()
@@ -463,6 +464,21 @@ void TemplatedOccupancyGridDisplay<octomap::ColorOcTree>::setVoxelColor(PointClo
 }
 
 
+bool OccupancyGridDisplay::updateFromTF()
+{
+    // get tf transform
+    Ogre::Vector3 pos;
+    Ogre::Quaternion orient;
+    if (!context_->getFrameManager()->getTransform(header_, pos, orient)) {
+      return false;
+    }
+
+    scene_node_->setOrientation(orient);
+    scene_node_->setPosition(pos);
+    return true;
+}
+
+
 template <typename OcTreeType>
 void TemplatedOccupancyGridDisplay<OcTreeType>::incomingMessageCallback(const octomap_msgs::OctomapConstPtr& msg)
 {
@@ -476,20 +492,14 @@ void TemplatedOccupancyGridDisplay<OcTreeType>::incomingMessageCallback(const oc
 
   ROS_DEBUG("Received OctomapBinary message (size: %d bytes)", (int)msg->data.size());
 
-  // get tf transform
-  Ogre::Vector3 pos;
-  Ogre::Quaternion orient;
-  if (!context_->getFrameManager()->getTransform(msg->header, pos, orient))
-  {
-    std::stringstream ss;
-    ss << "Failed to transform from frame [" << msg->header.frame_id << "] to frame ["
-        << context_->getFrameManager()->getFixedFrame() << "]";
-    setStatusStd(StatusProperty::Error, "Message", ss.str());
-    return;
+  header_ = msg->header;
+  if (!updateFromTF()) {
+      std::stringstream ss;
+      ss << "Failed to transform from frame [" << header_.frame_id << "] to frame ["
+          << context_->getFrameManager()->getFixedFrame() << "]";
+      setStatusStd(StatusProperty::Error, "Message", ss.str());
+      return;
   }
-
-  scene_node_->setOrientation(orient);
-  scene_node_->setPosition(pos);
 
   // creating octree
   OcTreeType* octomap = NULL;


### PR DESCRIPTION
Moves the Octomap grid with the frame defined in the header on every frame update.
This makes it possible to attach an Octomap to a moving frame (e.g. items on a conveyor belt).
This PR adds:
 - The header of the last Octomap message is stored (```header_```).
 - ```bool updateFromTF()``` updates the node frame using latest TF frame specified in the stored header.
 - ```updateFromTF()``` gets called inside ```update(float wall_dt, float ros_dt)``` (e.g. every time the Octomap gets rendered).

The additional node frame update does not seem to have any performance impact on rendering speed. Unless there is another reason not to do so, updating the frames regardless of the Octomap being static or moving can be default behaviour.

For compatibility, this commit cherrypicks cleanly on all versions of the plugin except for fuerte (tested on kinetic and indigo).

This PR is related to #12 but it doesn't solve the issue.