### PR TITLE
Update visualization on property changes with latched topics

### DIFF
--- a/src/occupancy_grid_display.cpp
+++ b/src/occupancy_grid_display.cpp
@@ -293,26 +293,32 @@ void OccupancyGridDisplay::setColor(double z_pos, double min_z, double max_z, do
 
 void OccupancyGridDisplay::updateTreeDepth()
 {
+  updateTopic();
 }
 
 void OccupancyGridDisplay::updateOctreeRenderMode()
 {
+  updateTopic();
 }
 
 void OccupancyGridDisplay::updateOctreeColorMode()
 {
+  updateTopic();
 }
 
 void OccupancyGridDisplay::updateAlpha()
 {
+  updateTopic();
 }
 
 void OccupancyGridDisplay::updateMaxHeight()
 {
+  updateTopic();
 }
 
 void OccupancyGridDisplay::updateMinHeight()
 {
+  updateTopic();
 }
 
 void OccupancyGridDisplay::clear()


### PR DESCRIPTION
OctoMaps are not redrawn until a new OctoMap message is received when changing properties, which is often never the case as octomap_server uses latched topics. This is a workaround that subscribed to the topic again, to receive the message from the latched topic again. This PR solves issue #8.

The other (less workaroundy) option to achieve this without having to re-receive the OctoMap message would include storing the received OctoMap which would increase the memory consumption of this display.