### PR TITLE
use automoc feature of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ find_package(Boost REQUIRED COMPONENTS thread )
 find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
 set(QT_LIBRARIES Qt5::Widgets)
 
+set(CMAKE_AUTOMOC ON)
+
 add_definitions(-DQT_NO_KEYWORDS)
 
 catkin_package(
@@ -35,16 +37,9 @@ link_directories(${catkin_LIBRARY_DIRS}
                  ${OCTOMAP_LIBRARY_DIRS}) 
 
 
-QT5_WRAP_CPP(MOC_FILES
-  include/octomap_rviz_plugins/occupancy_grid_display.h
-  include/octomap_rviz_plugins/occupancy_map_display.h
-  OPTIONS -DBOOST_TT_HAS_OPERATOR_HPP_INCLUDED -DBOOST_LEXICAL_CAST_INCLUDED 
-)
-
 set(SOURCE_FILES
   src/occupancy_grid_display.cpp
-  src/occupancy_map_display.cpp
-  ${MOC_FILES} 
+  src/occupancy_map_display.cpp 
 )
 
 add_library(${PROJECT_NAME} MODULE ${SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,12 @@ set(SOURCE_FILES
   src/occupancy_map_display.cpp 
 )
 
-add_library(${PROJECT_NAME} MODULE ${SOURCE_FILES})
+set(HEADER_FILES
+  include/octomap_rviz_plugins/occupancy_grid_display.h
+  include/octomap_rviz_plugins/occupancy_map_display.h
+)
+
+add_library(${PROJECT_NAME} MODULE ${SOURCE_FILES} ${HEADER_FILES})
 target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${catkin_LIBRARIES})
 target_compile_options(${PROJECT_NAME} PUBLIC "-Wno-register") # Avoid OGRE deprecaton warnings under C++17
 


### PR DESCRIPTION
This small clean-up made octomap_rviz_plugins build again on our CI on melodic

About the CMake version required: I think it was previously too low, the way you include Qt5 is actually only available since 2.8.11, you had to add qt5_use_module before which is now deprecated. automoc feature would have been available since 2.8.6 actually