### PR TITLE
Switch to the system-provided version of octomap.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>
   <depend>octomap_msgs</depend>
-  <depend>octomap</depend>
+  <depend>liboctomap-dev</depend>
   <depend>qtbase5-dev</depend>
   <depend>rclcpp</depend>
   <depend>rviz_common</depend>


### PR DESCRIPTION
This ensures that we have a consistent ABI between this package and any other packages in the system that use it. We'll eventually be removing the ROS-provided octomap package to ensure we don't run into future problems.

This was enabled by the merging of https://github.com/ros/rosdistro/pull/41623