### PR TITLE
Fix linkage to octomap(#48)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   Qt5::Widgets
-  ${OCTOMAP_LIBRARIES}
+  octomap
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC


### PR DESCRIPTION
With change to use the system liboctomap-dev the liboctomap_rviz_plugins.so does not get proper linkage and so plugin loading fails.

With this change it does.

```
ldd install/octomap_rviz_plugins/lib/liboctomap_rviz_plugins.so  | grep octo
        liboctomap_msgs__rosidl_typesupport_cpp.so => /opt/ros/humble/lib/liboctomap_msgs__rosidl_typesupport_cpp.so (0x00007fdde6004000)
        liboctomap.so.1.9 => /opt/ros/humble/lib/x86_64-linux-gnu/liboctomap.so.1.9 (0x00007fdde59c2000)
        liboctomath.so.1.9 => /opt/ros/humble/lib/x86_64-linux-gnu/liboctomath.so.1.9 (0x00007fdde35aa000)
```