### PR TITLE
Actually call find_package for octomap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
+# octomap is listed as liboctomap-dev on package.xml, so ament_auto_find_build_dependencies
+# can't find it, let's find it explicitly
+find_package(octomap REQUIRED)
+
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 set(CMAKE_AUTOMOC ON)
 


### PR DESCRIPTION
`ament_auto_find_build_dependencies` looks for CMake dependencies by assuming that the package name/rosdep key listed in the `package.xml` file corresponds to a CMake package name for which it is possible to call `find_package` (see https://github.com/ament/ament_cmake/blob/17d4da4f62233eea92c29a897b1a9ba4cc919979/ament_cmake_auto/cmake/ament_auto_find_build_dependencies.cmake#L61-L75) but that is not true for `octomap`, that is listed as `liboctomap-dev`, so to actually link the `octomap` imported target we need to explicitly call `find_package(octomap)`. 

